### PR TITLE
Remove mbstring.func_overload setting from php.ini

### DIFF
--- a/etc/php.d/bitrixenv.ini
+++ b/etc/php.d/bitrixenv.ini
@@ -22,7 +22,6 @@ pcre.recursion_limit = 14000
 realpath_cache_size = 4096k
 
 ; Utf-8 support
-mbstring.func_overload = 2
 mbstring.internal_encoding = UTF-8
 
 ; Configure PHP sessions


### PR DESCRIPTION
В текущей версии bitrix параметр mbstring.func_overload считается устаревшим